### PR TITLE
Returning error for prefix already registered

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -60,7 +60,7 @@ func (r *Reader) Prefix(p string) (io.Reader, error) {
 	}
 
 	if _, ok := r.prefixes[p]; ok {
-		fmt.Errorf("Prefix already registered: %s", p)
+		return nil, fmt.Errorf("Prefix already registered: %s", p)
 	}
 
 	pr, pw := io.Pipe()

--- a/reader_test.go
+++ b/reader_test.go
@@ -20,6 +20,10 @@ func TestReader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	_, err = r.Prefix("foo: ")
+	if err == nil {
+		t.Fatalf("expected prefix already registered error")
+	}
 	pBar, err := r.Prefix("bar: ")
 	if err != nil {
 		t.Fatalf("err: %s", err)


### PR DESCRIPTION
When the `Prefix already registered` error was checked, it was created via fmt.Errorf and immediately discarded, not returned. It's now returned immediately.

ps: it's my first pull request ever, hope I didn't mess up :)
